### PR TITLE
mm: Fix /proc/<pid>/smaps output format

### DIFF
--- a/fs/proc/task_mmu.c
+++ b/fs/proc/task_mmu.c
@@ -1064,7 +1064,6 @@ static int show_smap(struct seq_file *m, void *v)
 	if (vma_get_anon_name(vma)) {
 		seq_puts(m, "Name:           ");
 		seq_print_vma_name(m, vma);
-		seq_putc(m, '\n');
 	}
 
 	SEQ_PUT_DEC("Size:           ", vma->vm_end - vma->vm_start);


### PR DESCRIPTION
It breaks dumpsys meminfo.

Fixes: bf71e8c9d11a ("mm: Micro-optimize PID maps output for arm64")

Picked from e523233, or you could just merge upstream changes.